### PR TITLE
Bug 1291905 - Add capability to install Drush via composer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .project
+vendor

--- a/.openshift/action_hooks/build
+++ b/.openshift/action_hooks/build
@@ -1,8 +1,8 @@
 #!/bin/bash
-# This is a simple build script and will be executed on your CI system if 
+# This is a simple build script and will be executed on your CI system if
 # available.  Otherwise it will execute while your application is stopped
 # before the deploy step.  This script gets executed directly, so it
-# could be python, php, ruby, etc. 
+# could be python, php, ruby, etc.
 
 set -e
 
@@ -15,6 +15,7 @@ then
   exit 5
 fi
 
+DRUSH=${OPENSHIFT_REPO_DIR}vendor/bin/drush
 DRUPAL_DIR=${OPENSHIFT_DATA_DIR}drupal
 DRUPAL_SITE_DIR=${OPENSHIFT_DATA_DIR}sites
 
@@ -38,7 +39,7 @@ then
   echo
 
   mkdir -p ${OPENSHIFT_DATA_DIR}downloads
-  if ! drush dl drupal --destination=${OPENSHIFT_DATA_DIR}downloads --yes
+  if ! $DRUSH dl drupal --destination=${OPENSHIFT_DATA_DIR}downloads --yes --default-major=7
   then
     echo "ERROR: Unable download and install Drupal."
     exit 7
@@ -85,7 +86,7 @@ fi
 #
 ln -sfn ../../data/downloads/current ${OPENSHIFT_REPO_DIR}php
 if [ ! -d "${OPENSHIFT_REPO_DIR}php" ]
-then  
+then
   echo "ERROR: Unable to link the PHP directory, as the current Drupal instance is not a valid directory."
   exit 8
 fi

--- a/.openshift/action_hooks/deploy
+++ b/.openshift/action_hooks/deploy
@@ -8,6 +8,7 @@ set -e
 
 source $OPENSHIFT_CARTRIDGE_SDK_BASH
 
+DRUSH=${OPENSHIFT_REPO_DIR}vendor/bin/drush
 DRUPAL_SITE_DIR=${OPENSHIFT_DATA_DIR}sites
 DRUPAL_PRIVATE_DIR=${OPENSHIFT_DATA_DIR}private
 DRUPAL_SETTINGS=${DRUPAL_SITE_DIR}/default/settings.php
@@ -31,7 +32,7 @@ then
 
   #
   # Automatic installation only works with mysql.
-  # 
+  #
   if [ -z "$OPENSHIFT_MYSQL_DB_HOST" ]
   then
       echo 1>&2
@@ -57,7 +58,7 @@ then
   echo
   echo "Creating a new Drupal site at ${DRUPAL_SITE_DIR}/default"
   echo
-  if ! drush site-install standard --site-name=${OPENSHIFT_APP_NAME} --account-pass=$admin_pwd --db-url=mysql://$OPENSHIFT_MYSQL_DB_USERNAME:$OPENSHIFT_MYSQL_DB_PASSWORD@$OPENSHIFT_MYSQL_DB_HOST:$OPENSHIFT_MYSQL_DB_PORT/$OPENSHIFT_APP_NAME --yes
+  if ! $DRUSH site-install standard --site-name=${OPENSHIFT_APP_NAME} --account-pass=$admin_pwd --db-url=mysql://$OPENSHIFT_MYSQL_DB_USERNAME:$OPENSHIFT_MYSQL_DB_PASSWORD@$OPENSHIFT_MYSQL_DB_HOST:$OPENSHIFT_MYSQL_DB_PORT/$OPENSHIFT_APP_NAME --yes
   then
     echo "Unable to configure your Drupal installation"
     echo
@@ -83,9 +84,9 @@ if (array_key_exists('OPENSHIFT_APP_NAME', $_SERVER)) {
   $src = $_ENV;
 }
 $databases = array (
-  'default' => 
+  'default' =>
   array (
-    'default' => 
+    'default' =>
     array (
       'database' => $src['OPENSHIFT_APP_NAME'],
       'username' => $src['OPENSHIFT_MYSQL_DB_USERNAME'],

--- a/.openshift/action_hooks/pre_build
+++ b/.openshift/action_hooks/pre_build
@@ -1,6 +1,5 @@
 #!/bin/bash
-# This is a simple script and will be executed on your CI system if 
+# This is a simple script and will be executed on your CI system if
 # available.  Otherwise it will execute while your application is stopped
 # before the build step.  This script gets executed directly, so it
 # could be python, php, ruby, etc.
-

--- a/.openshift/cron/hourly/drupal_cron
+++ b/.openshift/cron/hourly/drupal_cron
@@ -1,2 +1,2 @@
 cd ${OPENSHIFT_REPO_DIR}php
-drush core-cron
+${OPENSHIFT_REPO_DIR}vendor/bin/drush core-cron

--- a/.openshift/pear.txt
+++ b/.openshift/pear.txt
@@ -1,1 +1,0 @@
-pear.drush.org/drush

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 Drupal on OpenShift
 ===================
 
-This Git repository helps you get up and running quickly w/ a Drupal
+This Git repository helps you get up and running quickly w/ a Drupal 7.x
 installation on OpenShift. It defaults to using MySQL, so when creating
 the application you'll want to select and install both MySQL and Cron
-(for running scheduled tasks). 
+(for running scheduled tasks).
 
     rhc app create drupal php-5.3 mysql-5.1 cron
 
@@ -97,4 +97,3 @@ version of Drupal from your data directory every time you push.  The
 runtime directory in your application is automatically recreated each
 push, so anything persistent must be in your Git repo or saved and
 retrieved from the data directory.
-

--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,5 @@
+{
+    "require": {
+        "drush/drush": "7.*"
+    }
+}


### PR DESCRIPTION
Drush no longer supports installation via pear. As a result,
installing drupal app using drupal-quickstart will fail as
Drush is not installed properly.

Several changes are added to drupal-quickstart to allow Drush
to be installed via composer instead of pear. Drush is now
installed correctly and eliminates the drupal installation
failures.

Bug 1291905
Link <https://bugzilla.redhat.com/show_bug.cgi?id=1291905>

Authored-by: Jeffrey D Johnson <jeffreyd@gmail.com>
Signed-off-by: Vu Dinh <vdinh@redhat.com>